### PR TITLE
feat: modal component 만들기

### DIFF
--- a/components/modal/AddBucketFolderModal.tsx
+++ b/components/modal/AddBucketFolderModal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Modal, ModalOverlay, ModalContent, Text } from '@chakra-ui/react';
+
+interface AddBucketFolderModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const AddBucketFolderModal = (props: AddBucketFolderModalProps) => (
+  <Modal {...props}>
+    <ModalOverlay />
+    <ModalContent bgColor="white" width={300} height={400}>
+      <Text color="black" textAlign="center">
+        hello world
+      </Text>
+    </ModalContent>
+  </Modal>
+);
+
+export default AddBucketFolderModal;

--- a/components/modal/EventModal.tsx
+++ b/components/modal/EventModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Modal, ModalOverlay, ModalContent, Text } from '@chakra-ui/react';
+
+interface EventModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * 일정 추가, 수정 모달
+ */
+const EventModal = (props: EventModalProps) => {
+  return (
+    <Modal {...props}>
+      <ModalOverlay />
+      <ModalContent bgColor="white" width={300} height={200}>
+        <Text color="black" textAlign="center">
+          hello world
+        </Text>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default EventModal;

--- a/components/modal/UpdateBucketModal.tsx
+++ b/components/modal/UpdateBucketModal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Modal, ModalOverlay, ModalContent, Text } from '@chakra-ui/react';
+
+interface UpdateBucketModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const UpdateBucketModal = (props: UpdateBucketModalProps) => (
+  <Modal {...props}>
+    <ModalOverlay />
+    <ModalContent bgColor="white" width={300} height={400}>
+      <Text color="black" textAlign="center">
+        hello world
+      </Text>
+    </ModalContent>
+  </Modal>
+);
+
+export default UpdateBucketModal;

--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -1,15 +1,22 @@
+import React from 'react';
+import { Button, useDisclosure } from '@chakra-ui/react';
+import { NextPageWithLayout } from '@/pages/_app';
 import PageHeader from '@/components/layouts/Header';
 import MainLayout from '@/components/layouts/MainLayout';
-import React from 'react';
-import { NextPageWithLayout } from '@/pages/_app';
+import AddBucketFolderModal from '@/components/modal/AddBucketFolderModal';
 
 const Event: NextPageWithLayout = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  
   return (
     <>
       <h1>일정</h1>
       <section>
         <h2>일정</h2>
       </section>
+
+      <Button onClick={onOpen}>Open Modal</Button>
+      <AddBucketFolderModal isOpen={isOpen} onClose={onClose} />
     </>
   );
 };


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#11

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 가장 기본적인 modal component를 만들었습니다
- chakra modal이 portal 방식으로 이미 되어있었고 useDisclosure 훅을 통해 modal, alert dialog, drawer 컴포넌트도 제어할 수 있게 되어있어서 변경을 최대한 적게했습니다.

### 사용 방법
- 구현부에선 모달에서 실행할 로직을 구현하고 사용부에선 useDisclousure 훅을 호출하고 모달 컴포넌트와 함께 모달을 제어할 상태 및 함수를 props로 넘깁니다.

### 시도하려고 했던 방법
1. 모달컴포넌트를 상태로 제어하는 방식이 아닌 전역적으로 지정해놓은 모달타입을 사용부에서 open함수와 함께 넘겨주어 ( ex) open({type: 'EventModal', props}) ) portal에서 호출하는 방식으로 한다.
2. 버튼을 클릭하면 로직안에서 모달을 띄우고 promise resolve되기 전까지 다른 작업들이 멈춰있도록 한다. 모달안에서 작업이 끝나고(promise.resolve(false)) 나오면 결과에 따라 분기를 시키거나 핸들러 안의 작업을 이어서 실행한다.

의견 자유롭게 남겨주시면 감사하겠습니다~