### PR TITLE
feat: 로그인 전에 초대 링크로 들어온 경우, 로그인해도 초대 코드 유지되도록

### DIFF
--- a/lib/supabase/apis/invitation.ts
+++ b/lib/supabase/apis/invitation.ts
@@ -21,8 +21,8 @@ export const getInvitationInfo = async (code: string) => {
     .from('invitations')
     .select(`*, groups ( name ), users ( nickname )`)
     .eq('code', code)
-    // @note: 생성시점이 min(= 현재 - 24시간) 보다 작다면 유효한 시점이라 판단.
-    .lt('created_time', minCreatedTime.toISOString());
+    // @note: 생성시점이 min(= 현재 - 24시간) 보다 커야 유효한 시점
+    .gt('created_time', minCreatedTime.toISOString());
   const invitationInfo = data?.[0];
 
   if (!invitationInfo || error) throw error;

--- a/lib/supabase/apis/invitation.ts
+++ b/lib/supabase/apis/invitation.ts
@@ -25,6 +25,6 @@ export const getInvitationInfo = async (code: string) => {
     .gt('created_time', minCreatedTime.toISOString());
   const invitationInfo = data?.[0];
 
-  if (!invitationInfo || error) throw error;
-  return invitationInfo as InvitationInfo;
+  if (error) throw error;
+  return invitationInfo as InvitationInfo | undefined;
 };

--- a/pages/api/auth/kakao-login.ts
+++ b/pages/api/auth/kakao-login.ts
@@ -7,16 +7,20 @@ export const config = {
   runtime: 'edge',
 };
 
+const withState = (url: string, state?: string | null) => `${url}/?state=${state}`;
+
 const edgeFunction: EdgeFunction = async (req) => {
   try {
     const { searchParams } = new URL(req.url);
     const code = searchParams.get('code');
+    const state = searchParams.get('state');
+
     if (!code) throw 'empty code';
 
     const responseByCode = await issueAccessToken(code);
     const { access_token, expires_in, refresh_token, refresh_token_expires_in } = responseByCode;
 
-    const res = NextResponse.redirect(HOSTING_URL, 302);
+    const res = NextResponse.redirect(withState(HOSTING_URL, state), 302);
 
     // @note: edge runtime에선 현재 쿠키가 두개 이상 set하면 첫번째꺼만 반영되는 이슈가 있음
     // 임시로 refresh_token을 먼저 쓰도록 하고, access_token set은 /api/auth/me 에서 진행되도록 한다.

--- a/pages/api/auth/kakao-login.ts
+++ b/pages/api/auth/kakao-login.ts
@@ -7,7 +7,7 @@ export const config = {
   runtime: 'edge',
 };
 
-const withState = (url: string, state?: string | null) => `${url}/?state=${state}`;
+const withState = (url: string, state?: string | null) => (state ? `${url}/?state=${state}` : url);
 
 const edgeFunction: EdgeFunction = async (req) => {
   try {

--- a/pages/api/invitation/verify.ts
+++ b/pages/api/invitation/verify.ts
@@ -24,6 +24,8 @@ const edgeFunction: EdgeFunction = async (req) => {
     const { code } = bodyScheme.parse(body);
 
     const invitationInfo = await getInvitationInfo(code);
+    if (!invitationInfo) throw 'invitation is empty';
+
     const now = new Date();
     const expired = addDays(invitationInfo.created_time, 1);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ import { useFetchJoinedGroupList } from '@/hooks/useFetchJoinedGroupList';
 
 const RootPage = () => {
   const router = useRouter();
-  const code = pickFirst(router.query.code);
+  const code = pickFirst(router.query.code) ?? pickFirst(router.query.state);
 
   const { user, isLoading: isLoadingUser, selectedGroupId, setGroupId } = useUser();
   const { data: invitationInfo, isLoading: isLoadingInvitationInfo } = useFetchInvitationInfo(code);
@@ -70,7 +70,7 @@ const RootPage = () => {
           ? `${invitationInfo.users.nickname}님이 당신을\n${invitationInfo.groups.name} 그룹으로 초대합니다.`
           : '가까운 사람들과\n일정, 버킷리스트를 함께 공유해보세요.'}
       </p>
-      <a href={KAKAO_LOGIN_URL}>카카오 로그인</a>
+      <a href={KAKAO_LOGIN_URL(code)}>카카오 로그인</a>
     </MainLayout>
   );
 };

--- a/utils/const.ts
+++ b/utils/const.ts
@@ -9,14 +9,16 @@ export const KAKAO_LOGIN_REDIRECT_URL =
 export const KAKAO_LOGOUT_REDIRECT_URL =
   process.env.NEXT_PUBLIC_KAKAO_LOGOUT_REDIRECT_URL || 'http://localhost:3000/api/auth/kakao-logout';
 
-export const KAKAO_LOGIN_URL = queryString.stringifyUrl({
-  url: 'https://kauth.kakao.com/oauth/authorize',
-  query: {
-    client_id: KAKAO_CLIENT_ID,
-    redirect_uri: KAKAO_LOGIN_REDIRECT_URL,
-    response_type: 'code',
-  },
-});
+export const KAKAO_LOGIN_URL = (state?: string | null) =>
+  queryString.stringifyUrl({
+    url: 'https://kauth.kakao.com/oauth/authorize',
+    query: {
+      client_id: KAKAO_CLIENT_ID,
+      redirect_uri: KAKAO_LOGIN_REDIRECT_URL,
+      response_type: 'code',
+      state,
+    },
+  });
 export const KAKAO_LOGOUT_URL = queryString.stringifyUrl({
   url: 'https://kauth.kakao.com/oauth/logout',
   query: {


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#36

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

- 로그인하지 않은 초대 코드가 포함된 URL로 접근하는 경우, 로그인 한뒤 초대 코드가 사라집니다.
- 그래서 state 기능을 써서 로그인 후에 초대 코드가 유지될 수 있도록 변경했습니다.
- 기타: 초대 코드 검증 로직이 잘못되어있어 수정했습니다.