### PR TITLE
feat: splash page 추가 (디자인 미확정)

### DIFF
--- a/components/loading/SplashPage.tsx
+++ b/components/loading/SplashPage.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+import { SplashLogoIcon } from '../icons';
+
+export const SplashPage = () => {
+  return (
+    <Container>
+      <SplashLogoIcon />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/hooks/useProtectedRoute.ts
+++ b/hooks/useProtectedRoute.ts
@@ -1,10 +1,13 @@
 import { useUser } from '@/store/useUser';
+import { useTimeout } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export const useProtectedRoute = (isProtectedPage = false, redirectUrl = '/') => {
   const router = useRouter();
-  const { user, isLoading, login } = useUser();
+  const { user, isLoading: isLoadingUser, login } = useUser();
+  const [isMinTimePassed, setIsMinTimePassed] = useState(false);
+  const isLoading = isLoadingUser || !isMinTimePassed;
 
   // @note:
   // 1. 로그인 전에 로딩 페이지를 보여주는 이유는
@@ -26,6 +29,10 @@ export const useProtectedRoute = (isProtectedPage = false, redirectUrl = '/') =>
       router.replace(redirectUrl);
     }
   }, [isLoading, isProtectedPage, redirectUrl, router, user]);
+
+  // @note: 너무 짧은 시간 동안 스플래시 페이지가 보여지면 깜빡거리는 느낌을 받을 수 있기 때문에
+  // 최소 1초 동안은 스플래시 페이지를 보여주기 위해 useTimeout를 사용합니다.
+  useTimeout(() => setIsMinTimePassed(true), 1000);
 
   return { showLoadingPage };
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import theme from '@/styles/theme';
 import { NextPage } from 'next';
 import ErrorBoundary from '@/components/errorBoundary/ErrorBoundary';
 import { useProtectedRoute } from '@/hooks/useProtectedRoute';
+import { SplashPage } from '@/components/loading/SplashPage';
 
 export type NextPageWithLayout<P = object, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -41,7 +42,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
       <QueryClientProvider client={queryClient}>
         <ChakraProvider theme={theme} resetCSS cssVarsRoot="body">
           <ErrorBoundary fallback={<div>에러 페이지</div>}>
-            {showLoadingPage ? 'loading...' : getLayout(<Component {...pageProps} />)}
+            {showLoadingPage ? <SplashPage /> : getLayout(<Component {...pageProps} />)}
           </ErrorBoundary>
         </ChakraProvider>
       </QueryClientProvider>

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -3,16 +3,9 @@ import MainLayout from '@/components/layouts/MainLayout';
 import { NextPageWithLayout } from '@/pages/_app';
 import { useUser } from '@/store/useUser';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 
 const MyPage: NextPageWithLayout = () => {
-  const router = useRouter();
   const { user, logout } = useUser();
-
-  const handleLogout = async () => {
-    await logout();
-    router.push('/');
-  };
 
   return (
     <>
@@ -21,7 +14,7 @@ const MyPage: NextPageWithLayout = () => {
         <h2>마이페이지</h2>
         <Image src={user?.profile_image || ''} alt="profile image" width={60} height={60} />
         <h3>{user?.nickname}</h3>
-        <button onClick={handleLogout}>로그아웃</button>
+        <button onClick={logout}>로그아웃</button>
       </section>
     </>
   );

--- a/store/useUser.ts
+++ b/store/useUser.ts
@@ -44,7 +44,7 @@ export const useUser = create<UserState>((set) => ({
     // @note: supabase에서도 로그아웃 처리합니다.
     await supabase.auth.signOut();
 
-    set({ user: null, selectedGroupId: null });
+    location.replace('/');
   },
   setGroupId: (groupId: number) => {
     set({ selectedGroupId: groupId });


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#58

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용


https://user-images.githubusercontent.com/22021344/218482053-b41070eb-baf0-45b3-a12a-64b58d3bd954.mov

- 우선 아직 디자인이 확정된 건 아닙니다.
- 최소 1초간 스플래시 페이지가 뜨도록 변경했습니다.
- (기타) 찰나에 로딩페이지가 보이는 이슈가 있어, 로그아웃 시 user = null 로 설정하는게 아니라, url을 `/`로 이동시키도록 변경했습니다.

