### PR TITLE
fix: 개발 시 safari에서 로그인 안되는 이슈 수정

### DIFF
--- a/pages/api/auth/kakao-login.ts
+++ b/pages/api/auth/kakao-login.ts
@@ -29,14 +29,12 @@ const edgeFunction: EdgeFunction = async (req) => {
       path: '/',
       maxAge: refresh_token_expires_in,
       httpOnly: true,
-      secure: true,
       sameSite: 'strict',
     });
     res.cookies.set(COOKIE_KAKAO_ACCESS_TOKEN_NAME, access_token, {
       path: '/',
       maxAge: expires_in,
       httpOnly: true,
-      secure: true,
       sameSite: 'strict',
     });
 

--- a/pages/api/auth/me.ts
+++ b/pages/api/auth/me.ts
@@ -56,7 +56,6 @@ const edgeFunction: EdgeFunction = async (req) => {
         path: '/',
         maxAge: expiresIn,
         httpOnly: true,
-        secure: true,
         sameSite: 'strict',
       });
     }

--- a/pages/api/auth/me.ts
+++ b/pages/api/auth/me.ts
@@ -73,9 +73,6 @@ const edgeFunction: EdgeFunction = async (req) => {
         },
       }
     );
-    // clear cookie
-    // res.cookies.delete(COOKIE_KAKAO_REFRESH_TOKEN_NAME);
-    // res.cookies.delete(COOKIE_KAKAO_ACCESS_TOKEN_NAME);
     return res;
   }
 };


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#63

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

- 상범님 제보로 확인했습니다.
- 원인은 set-cookie 시 `secure: true`를 주어서 http:// 스킴에서는 적용되지 않아 발생했습니다.
- 해결은 위 설정을 set-cookie에서 제거했습니다. 
   - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
   - 위 문서를 읽어보니 현재 SameSite: strict와 httpOnly 옵션을 주고 있기 때문에 앞으로 크게 문제될 점은 없어보입니다.