### PR TITLE
feat: font 설정 추가 (pretendard var, happiness sans)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { NextPage } from 'next';
 import ErrorBoundary from '@/components/errorBoundary/ErrorBoundary';
 import { useProtectedRoute } from '@/hooks/useProtectedRoute';
 import { SplashPage } from '@/components/loading/SplashPage';
+import Fonts from '@/styles/Font';
 
 export type NextPageWithLayout<P = object, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -41,6 +42,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
       </Head>
       <QueryClientProvider client={queryClient}>
         <ChakraProvider theme={theme} resetCSS cssVarsRoot="#app">
+          <Fonts />
           <ErrorBoundary fallback={<div>에러 페이지</div>}>
             {showLoadingPage ? <SplashPage /> : getLayout(<Component {...pageProps} />)}
           </ErrorBoundary>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,7 @@ import Router, { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useFetchInvitationInfo } from '@/hooks/useFetchInvitationInfo';
 import { useFetchJoinedGroupList } from '@/hooks/useFetchJoinedGroupList';
+import { Heading } from '@chakra-ui/react';
 
 // @note: root page flow
 // 1-1. 로그인 여부 확인 -> 로그인되어 있다면 참여한 그룹 리스트 확인
@@ -65,11 +66,11 @@ const RootPage = () => {
 
   return (
     <MainLayout hideBottomNavigation>
-      <p>
+      <Heading>
         {invitationInfo
           ? `${invitationInfo.users.nickname}님이 당신을\n${invitationInfo.groups.name} 그룹으로 초대합니다.`
           : '가까운 사람들과\n일정, 버킷리스트를 함께 공유해보세요.'}
-      </p>
+      </Heading>
       <a href={KAKAO_LOGIN_URL(code)}>카카오 로그인</a>
     </MainLayout>
   );

--- a/styles/Font.tsx
+++ b/styles/Font.tsx
@@ -1,0 +1,26 @@
+import { Global } from '@emotion/react';
+
+const Fonts = () => (
+  <Global
+    styles={`
+      @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/variable/pretendardvariable-dynamic-subset.css");
+
+      @font-face {
+        font-family: 'Happiness-Sans';
+        font-style: normal;
+        font-weight: 700;
+        font-display: swap;
+        src: local('Happiness-Sans-Bold'), url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2205@1.0/Happiness-Sans-Bold.woff2') format('woff2');
+      }
+      @font-face {
+        font-family: 'Happiness-Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: local(Happiness-Sans-Regular), url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2205@1.0/Happiness-Sans-Regular.woff2') format('woff2');
+      }
+      `}
+  />
+);
+
+export default Fonts;

--- a/styles/theme/foundations/fonts.ts
+++ b/styles/theme/foundations/fonts.ts
@@ -1,5 +1,6 @@
 const fonts = {
-  fontFamily: 'Roboto, sans-serif',
+  body: `"Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif`,
+  heading: `'Happiness-Sans'`,
 };
 
 export default fonts;


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#66

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

- 두 폰트는 모두 외부 cdn에서 가져옵니다.
- 적용한 방식은 chakra 문서를 참고했습니다.
  - https://chakra-ui.com/community/recipes/using-fonts#option-2-using-font-face
- body에는 pretendard 가변 글꼴 적용했습니다.
  -  https://github.com/orioncactus/pretendard#%EA%B0%80%EB%B3%80-%EA%B8%80%EA%BC%B4
- heading에만 happiness sans를 적용했습니다. (논의 필요)
  - https://noonnu.cc/font_page/900
  - heading에만 적용한 이유는 `styles/theme/foundations/fonts.ts`에 fonts 객체의 키가 
  - chakra ui에서 제공하는 컴포넌트에 대응되는 것 같더라구요. 
  - 적절한 컴포넌트가 딱히 안보여서 일단 heading 컴포넌트에만 happiness sans가 적용되도록 했습니다.
  - 만약 별로라면 global classname 선언해서 적용하면 되니 의견 주시면 감사하겠습니다.
