### PR TITLE
feat: 토스트 컴포넌트 & 훅 추가

### DIFF
--- a/components/icons/ArrowRightIcon20.tsx
+++ b/components/icons/ArrowRightIcon20.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { SVGProps } from 'react';
+const SvgArrowRightIcon20 = (props: SVGProps<SVGSVGElement>) => (
+  <svg width={20} height={20} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M3.125 10h13.75M11.25 4.375 16.875 10l-5.625 5.625"
+      stroke="#1E1F20"
+      strokeWidth={1.25}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+export default SvgArrowRightIcon20;

--- a/components/icons/ArrowRightIcon32.tsx
+++ b/components/icons/ArrowRightIcon32.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { SVGProps } from 'react';
+const SvgArrowRightIcon32 = (props: SVGProps<SVGSVGElement>) => (
+  <svg width={32} height={32} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path d="M5 16h22m-9-9 9 9-9 9" stroke="#1E1F20" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+export default SvgArrowRightIcon32;

--- a/components/icons/ToastAlertIcon.tsx
+++ b/components/icons/ToastAlertIcon.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { SVGProps } from 'react';
+const SvgToastAlertIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg width={40} height={40} viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <g filter="url(#ToastAlertIcon_svg__a)">
+      <circle cx={20} cy={20} r={16} fill="#F54141" />
+    </g>
+    <path d="M20 13v9.333" stroke="#fff" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M20 28a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" fill="#fff" />
+    <defs>
+      <filter
+        id="ToastAlertIcon_svg__a"
+        x={0}
+        y={0}
+        width={40}
+        height={40}
+        filterUnits="userSpaceOnUse"
+        colorInterpolationFilters="sRGB"
+      >
+        <feFlood floodOpacity={0} result="BackgroundImageFix" />
+        <feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
+        <feOffset />
+        <feGaussianBlur stdDeviation={2} />
+        <feComposite in2="hardAlpha" operator="out" />
+        <feColorMatrix values="0 0 0 0 0.960784 0 0 0 0 0.254902 0 0 0 0 0.254902 0 0 0 0.4 0" />
+        <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_583_5611" />
+        <feBlend in="SourceGraphic" in2="effect1_dropShadow_583_5611" result="shape" />
+      </filter>
+    </defs>
+  </svg>
+);
+export default SvgToastAlertIcon;

--- a/components/icons/ToastSuccessIcon.tsx
+++ b/components/icons/ToastSuccessIcon.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { SVGProps } from 'react';
+const SvgToastSuccessIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg width={40} height={40} viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <g filter="url(#ToastSuccessIcon_svg__a)">
+      <circle cx={20} cy={20} r={16} fill="#23CF69" />
+    </g>
+    <path
+      d="M26.875 15.188 19.312 25.5l-5.156-5.844"
+      stroke="#F6F8F9"
+      strokeWidth={2.2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <defs>
+      <filter
+        id="ToastSuccessIcon_svg__a"
+        x={0}
+        y={0}
+        width={40}
+        height={40}
+        filterUnits="userSpaceOnUse"
+        colorInterpolationFilters="sRGB"
+      >
+        <feFlood floodOpacity={0} result="BackgroundImageFix" />
+        <feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
+        <feOffset />
+        <feGaussianBlur stdDeviation={2} />
+        <feComposite in2="hardAlpha" operator="out" />
+        <feColorMatrix values="0 0 0 0 0.137255 0 0 0 0 0.811765 0 0 0 0 0.411765 0 0 0 0.4 0" />
+        <feBlend in2="BackgroundImageFix" result="effect1_dropShadow_583_5595" />
+        <feBlend in="SourceGraphic" in2="effect1_dropShadow_583_5595" result="shape" />
+      </filter>
+    </defs>
+  </svg>
+);
+export default SvgToastSuccessIcon;

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -1,4 +1,5 @@
-export { default as ArrowRightIcon } from './ArrowRightIcon';
+export { default as ArrowRightIcon20 } from './ArrowRightIcon20';
+export { default as ArrowRightIcon32 } from './ArrowRightIcon32';
 export { default as BlackDownIcon } from './BlackDownIcon';
 export { default as CalendarIcon } from './CalendarIcon';
 export { default as CheckIcon20 } from './CheckIcon20';
@@ -17,4 +18,6 @@ export { default as PawIcon } from './PawIcon';
 export { default as PlusWhiteIcon } from './PlusWhiteIcon';
 export { default as RabbitWithCarIcon } from './RabbitWithCarIcon';
 export { default as SplashLogoIcon } from './SplashLogoIcon';
+export { default as ToastAlertIcon } from './ToastAlertIcon';
+export { default as ToastSuccessIcon } from './ToastSuccessIcon';
 export { default as TrashCanIcon } from './TrashCanIcon';

--- a/components/toasts/Toast.tsx
+++ b/components/toasts/Toast.tsx
@@ -1,0 +1,30 @@
+import { Box, Text } from '@chakra-ui/react';
+import { CustomToastProps } from '@/hooks/shared/useCustomToast';
+import styled from '@emotion/styled';
+import theme from '@/styles/theme';
+import { ToastAlertIcon, ToastSuccessIcon } from '@/components/icons';
+
+const Toast = ({ message, type }: CustomToastProps) => {
+  return (
+    <ToastWrapper>
+      {type === 'error' && <ToastAlertIcon />}
+      {type === 'success' && <ToastSuccessIcon />}
+      <Text textStyle={'body2'} color={'white'}>
+        {message}
+      </Text>
+    </ToastWrapper>
+  );
+};
+
+const ToastWrapper = styled(Box)`
+  width: 335px;
+  height: 60px;
+  background: ${theme.colors.grey[9]};
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+`;
+
+export default Toast;

--- a/components/toasts/Toast.tsx
+++ b/components/toasts/Toast.tsx
@@ -1,14 +1,14 @@
 import { Box, Text } from '@chakra-ui/react';
-import { CustomToastProps } from '@/hooks/shared/useCustomToast';
 import styled from '@emotion/styled';
 import theme from '@/styles/theme';
 import { ToastAlertIcon, ToastSuccessIcon } from '@/components/icons';
+import { CustomToastProps, TOAST_TYPE } from '@/hooks/shared/useCustomToast/type';
 
 const Toast = ({ message, type }: CustomToastProps) => {
   return (
     <ToastWrapper>
-      {type === 'error' && <ToastAlertIcon />}
-      {type === 'success' && <ToastSuccessIcon />}
+      {type === TOAST_TYPE.ERROR && <ToastAlertIcon />}
+      {type === TOAST_TYPE.SUCCESS && <ToastSuccessIcon />}
       <Text textStyle={'body2'} color={'white'}>
         {message}
       </Text>

--- a/components/toasts/Toast.tsx
+++ b/components/toasts/Toast.tsx
@@ -2,13 +2,13 @@ import { Box, Text } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import theme from '@/styles/theme';
 import { ToastAlertIcon, ToastSuccessIcon } from '@/components/icons';
-import { CustomToastProps, TOAST_TYPE } from '@/hooks/shared/useCustomToast/type';
+import { CustomToastProps } from '@/hooks/shared/useCustomToast/type';
 
 const Toast = ({ message, type }: CustomToastProps) => {
   return (
     <ToastWrapper>
-      {type === TOAST_TYPE.ERROR && <ToastAlertIcon />}
-      {type === TOAST_TYPE.SUCCESS && <ToastSuccessIcon />}
+      {type === 'error' && <ToastAlertIcon />}
+      {type === 'success' && <ToastSuccessIcon />}
       <Text textStyle={'body2'} color={'white'}>
         {message}
       </Text>

--- a/hooks/shared/useCustomToast.tsx
+++ b/hooks/shared/useCustomToast.tsx
@@ -6,8 +6,6 @@ export const TOAST_DURATION = 2000;
 export const TOAST_TYPE = {
   SUCCESS: 'success',
   ERROR: 'error',
-  WARNING: 'warning',
-  INFO: 'info',
 } as const;
 
 export type ToastType = (typeof TOAST_TYPE)[keyof typeof TOAST_TYPE];

--- a/hooks/shared/useCustomToast.tsx
+++ b/hooks/shared/useCustomToast.tsx
@@ -1,0 +1,36 @@
+import { useToast as useChakraToast } from '@chakra-ui/react';
+import Toast from '@/components/toasts/Toast';
+
+export const TOAST_DURATION = 2000;
+
+export const TOAST_TYPE = {
+  SUCCESS: 'success',
+  ERROR: 'error',
+  WARNING: 'warning',
+  INFO: 'info',
+} as const;
+
+export type ToastType = (typeof TOAST_TYPE)[keyof typeof TOAST_TYPE];
+
+export interface CustomToastProps {
+  message: string;
+  type: ToastType;
+}
+
+export const useCustomToast = () => {
+  const toast = useChakraToast();
+
+  const openToast = ({ message, type }: CustomToastProps) => {
+    return toast({
+      position: 'top',
+      duration: TOAST_DURATION,
+      render: () => <Toast message={message} type={type} />,
+    });
+  };
+
+  return {
+    openToast,
+  };
+};
+
+export default useCustomToast;

--- a/hooks/shared/useCustomToast/index.tsx
+++ b/hooks/shared/useCustomToast/index.tsx
@@ -1,19 +1,8 @@
 import { useToast as useChakraToast } from '@chakra-ui/react';
 import Toast from '@/components/toasts/Toast';
+import { CustomToastProps } from '@/hooks/shared/useCustomToast/type';
 
-export const TOAST_DURATION = 2000;
-
-export const TOAST_TYPE = {
-  SUCCESS: 'success',
-  ERROR: 'error',
-} as const;
-
-export type ToastType = (typeof TOAST_TYPE)[keyof typeof TOAST_TYPE];
-
-export interface CustomToastProps {
-  message: string;
-  type: ToastType;
-}
+const TOAST_DURATION = 2000;
 
 export const useCustomToast = () => {
   const toast = useChakraToast();

--- a/hooks/shared/useCustomToast/type.ts
+++ b/hooks/shared/useCustomToast/type.ts
@@ -1,0 +1,11 @@
+export const TOAST_TYPE = {
+  SUCCESS: 'success',
+  ERROR: 'error',
+} as const;
+
+export type ToastType = (typeof TOAST_TYPE)[keyof typeof TOAST_TYPE];
+
+export interface CustomToastProps {
+  message: string;
+  type: ToastType;
+}

--- a/hooks/shared/useCustomToast/type.ts
+++ b/hooks/shared/useCustomToast/type.ts
@@ -1,9 +1,4 @@
-export const TOAST_TYPE = {
-  SUCCESS: 'success',
-  ERROR: 'error',
-} as const;
-
-export type ToastType = (typeof TOAST_TYPE)[keyof typeof TOAST_TYPE];
+export type ToastType = 'success' | 'error';
 
 export interface CustomToastProps {
   message: string;

--- a/public/assets/ToastAlertIcon.svg
+++ b/public/assets/ToastAlertIcon.svg
@@ -1,0 +1,19 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_583_5611)">
+<circle cx="20" cy="20" r="16" fill="#F54141"/>
+</g>
+<path d="M20 13V22.3333" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20 28C20.5523 28 21 27.5523 21 27C21 26.4477 20.5523 26 20 26C19.4477 26 19 26.4477 19 27C19 27.5523 19.4477 28 20 28Z" fill="white"/>
+<defs>
+<filter id="filter0_d_583_5611" x="0" y="0" width="40" height="40" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.960784 0 0 0 0 0.254902 0 0 0 0 0.254902 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_583_5611"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_583_5611" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/assets/ToastSuccessIcon.svg
+++ b/public/assets/ToastSuccessIcon.svg
@@ -1,0 +1,18 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_583_5595)">
+<circle cx="20" cy="20" r="16" fill="#23CF69"/>
+</g>
+<path d="M26.875 15.1875L19.3125 25.5L14.1562 19.6562" stroke="#F6F8F9" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<filter id="filter0_d_583_5595" x="0" y="0" width="40" height="40" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.137255 0 0 0 0 0.811765 0 0 0 0 0.411765 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_583_5595"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_583_5595" result="shape"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#78

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<img width="485" alt="스크린샷 2023-02-23 오전 3 21 46" src="https://user-images.githubusercontent.com/35549653/220723171-edae191b-cb8a-4bfe-b890-46e9186322af.png">

토스트 컴포넌트를 공통화(마크업, duration 등)하기 위해 
커스텀된 토스트 컴포넌트와 해당 토스트를 위한 훅을 추가했습니다.

사용처에서는

```

  const { openToast } = useCustomToast();

  const handleClick = () => {
    openToast({
      message: '일정이 편집되었습니다',
      type: TOAST_TYPE.SUCCESS,
    });
  };

```

위와 같이 사용하시면 됩니다! 
