### PR TITLE
feat: theme 사용 방식 일원화 + theme 타입 추론 강화

### DIFF
--- a/components/bucketFolder/BucketFolderItem.tsx
+++ b/components/bucketFolder/BucketFolderItem.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { Text, useDisclosure } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import UpdateBucketFolderModal from '@/components/modals/bucketList/UpdateBucketFolderModal';
+import theme from '@/styles/theme';
 
 const BucketFolderItem = ({ folder }: { folder: BucketFolder }) => {
   const router = useRouter();
@@ -35,8 +36,8 @@ const BucketFolder = styled.li`
   justify-content: space-between;
   width: 100%;
   height: 70px;
-  background: ${({ theme }) => theme.colors.white};
-  border: 1px solid ${({ theme }) => theme.colors.grey[2]};
+  background: ${theme.colors.white};
+  border: 1px solid ${theme.colors.grey[2]};
   border-radius: 12px;
   align-items: center;
   padding: 0 20px;

--- a/components/bucketFolder/BucketFolderList.tsx
+++ b/components/bucketFolder/BucketFolderList.tsx
@@ -6,6 +6,7 @@ import { Button, useDisclosure } from '@chakra-ui/react';
 import AddBucketFolderModal from '@/components/modals/bucketList/AddBucketFolderModal';
 import BucketFolderItem from '@/components/bucketFolder/BucketFolderItem';
 import PartialLoader from '@/components/loading/PartialLoader';
+import theme from '@/styles/theme';
 
 const MAX_LIST_LENGTH = 10;
 
@@ -50,8 +51,8 @@ const StyledList = styled.ul`
 
 const AddFolderButton = styled(Button)`
   width: 100%;
-  background: ${({ theme }) => theme.colors.white};
-  border: 1px solid ${({ theme }) => theme.colors.grey[2]};
+  background: ${theme.colors.white};
+  border: 1px solid ${theme.colors.grey[2]};
   border-radius: 12px;
   height: 70px;
 `;

--- a/components/bucketItem/BucketItem.tsx
+++ b/components/bucketItem/BucketItem.tsx
@@ -4,6 +4,7 @@ import { Text, useDisclosure } from '@chakra-ui/react';
 import PawButton from '@/components/buttons/PawButton';
 import styled from '@emotion/styled';
 import { useMutateBucketItems } from '@/hooks/bucketlist/useMutateBucketItems';
+import theme from '@/styles/theme';
 
 const BucketItem = ({ item }: { item: TBucketItem }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -45,7 +46,7 @@ const Item = styled.li`
   align-items: center;
   width: 100%;
   height: 64px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.grey[2]};
+  border-bottom: 1px solid ${theme.colors.grey[2]};
   padding: 8px 20px;
   cursor: pointer;
 `;

--- a/components/inputs/ContentTextarea.tsx
+++ b/components/inputs/ContentTextarea.tsx
@@ -22,7 +22,7 @@ const ContentTextarea = (props: TextareaProps) => {
 
 const StyledTextarea = styled(Textarea)`
   overflow: hidden;
-  border: 1px solid ${({ theme }) => theme.colors.grey[2]};
+  border: 1px solid ${theme.colors.grey[2]};
   border-radius: 6px;
   padding: 10px;
 `;

--- a/components/memberList/MemberItem.tsx
+++ b/components/memberList/MemberItem.tsx
@@ -1,3 +1,4 @@
+import theme from '@/styles/theme';
 import styled from '@emotion/styled';
 import Image from 'next/image';
 
@@ -21,7 +22,7 @@ const MemberItemWrap = styled.div`
   justify-content: flex-start;
   align-items: center;
   padding: 10px 0 12px;
-  border-bottom: 1px solid ${(props) => props.theme.colors.grey[2]};
+  border-bottom: 1px solid ${theme.colors.grey[2]};
 `;
 const MemberItemProfileImage = styled(Image)`
   width: 48px;
@@ -37,16 +38,16 @@ const MemberItemIsMe = styled.span`
 
   width: 17px;
   height: 17px;
-  background-color: ${(props) => props.theme.colors.grey[9]};
+  background-color: ${theme.colors.grey[9]};
   border-radius: 50%;
   margin-right: 4px;
 
-  color: ${(props) => props.theme.colors.white};
+  color: ${theme.colors.white};
   font-weight: 700;
   font-size: 11px;
   line-height: 100%;
   letter-spacing: 0.025em;
 `;
 const MemberItemNickname = styled.span`
-  ${(props) => props.theme.textStyles.body1}
+  ${theme.textStyles.body1};
 `;

--- a/components/memberList/MemberList.tsx
+++ b/components/memberList/MemberList.tsx
@@ -1,5 +1,6 @@
 import { useFetchMemberList } from '@/hooks/member/useFetchMemberList';
 import { useUser } from '@/store/useUser';
+import theme from '@/styles/theme';
 import { Button } from '@chakra-ui/button';
 import { useDisclosure } from '@chakra-ui/react';
 import styled from '@emotion/styled';
@@ -27,18 +28,18 @@ export const MemberList = () => {
 
 const MemberListWrap = styled.section`
   padding: 0 20px;
-  border-bottom: 1px solid ${(props) => props.theme.colors.grey[2]};
+  border-bottom: 1px solid ${theme.colors.grey[2]};
 `;
 const MemberListHeader = styled.h3`
   padding: 12px 0;
-  ${(props) => props.theme.textStyles.h3}
+  ${theme.textStyles.h3};
 `;
 const AddMemberButton = styled(Button)`
   width: 100%;
   height: auto;
   margin: 20px 0;
   padding: 16px 0;
-  ${(props) => props.theme.textStyles.buttonSmall}
-  color: ${(props) => props.theme.colors.grey[1]};
-  background-color: ${(props) => props.theme.colors.grey[10]};
+  ${theme.textStyles.buttonSmall};
+  color: ${theme.colors.grey[1]};
+  background-color: ${theme.colors.grey[10]};
 `;

--- a/components/modals/bucketList/UpdateBucketItemModal.tsx
+++ b/components/modals/bucketList/UpdateBucketItemModal.tsx
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
 import BaseButton from '@/components/buttons/BaseButton';
 import { useMutateBucketItems } from '@/hooks/bucketlist/useMutateBucketItems';
 import { TrashCanIcon } from '@/components/icons';
+import theme from '@/styles/theme';
 
 interface UpdateBucketItemModalProps {
   isOpen: boolean;
@@ -90,9 +91,9 @@ const UpdateBucketItemModal = ({ isOpen, onClose, description, title, id }: Upda
 };
 
 const StyledModalHeader = styled(ModalHeader)`
-  background-color: ${({ theme }) => theme.colors.grey[8]};
+  background-color: ${theme.colors.grey[8]};
   border-radius: 6px 6px 0px 0px;
-  color: ${({ theme }) => theme.colors.grey[1]};
+  color: ${theme.colors.grey[1]};
   height: 56px;
 `;
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import styled from '@emotion/styled';
 import { useFetchInvitationInfo } from '@/hooks/invitation/useFetchInvitationInfo';
 import { useFetchJoinedGroupList } from '@/hooks/group/useFetchJoinedGroupList';
 import { Heading } from '@chakra-ui/react';
+import theme from '@/styles/theme';
 
 // @note: root page flow
 // 1-1. 로그인 여부 확인 -> 로그인되어 있다면 참여한 그룹 리스트 확인
@@ -127,12 +128,12 @@ const KakaoLoginButton = styled(Button)`
   width: 100%;
   height: 50px;
   border-radius: 8px;
-  background-color: ${(props) => props.theme.colors.kakaoBgColor};
+  background-color: ${theme.colors.kakaoBgColor};
 `;
 const KakaoLoginButtonText = styled.span`
   margin-left: 4px;
-  ${(props) => props.theme.textStyles.buttonMedium}
-  color: ${(props) => props.theme.colors.black};
+  ${theme.textStyles.buttonMedium};
+  color: ${theme.colors.black};
 `;
 const Space = styled.div`
   flex: 1;

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -3,6 +3,7 @@ import MainLayout from '@/components/layouts/MainLayout';
 import { MemberList } from '@/components/memberList/MemberList';
 import { NextPageWithLayout } from '@/pages/_app';
 import { useUser } from '@/store/useUser';
+import theme from '@/styles/theme';
 import styled from '@emotion/styled';
 
 const MyPage: NextPageWithLayout = () => {
@@ -41,8 +42,8 @@ const MyPageHeader = styled.h1`
 
   height: 58px;
   padding: 0 20px;
-  ${(props) => props.theme.textStyles.h3}
-  border-bottom: 1px solid ${(props) => props.theme.colors.grey[2]};
+  ${theme.textStyles.h3};
+  border-bottom: 1px solid ${theme.colors.grey[2]};
 `;
 const MyPageContent = styled.section`
   position: absolute;
@@ -62,7 +63,7 @@ const OtherButton = styled.button`
   width: 100%;
   padding: 22px 20px;
   text-align: left;
-  border-bottom: 1px solid ${(props) => props.theme.colors.grey[2]};
-  ${(props) => props.theme.textStyles.buttonMedium}
-  color: ${(props) => props.theme.colors.grey[10]};
+  border-bottom: 1px solid ${theme.colors.grey[2]};
+  ${theme.textStyles.buttonMedium};
+  color: ${theme.colors.grey[10]};
 `;

--- a/styles/theme/foundations/colors.ts
+++ b/styles/theme/foundations/colors.ts
@@ -1,4 +1,4 @@
-const colors = {
+export const colors = {
   primary: '#FF541E',
   secondary: '#1E1E1F',
   transparent: 'transparent',
@@ -25,5 +25,3 @@ const colors = {
   },
   kakaoBgColor: '#fee500',
 };
-
-export default colors;

--- a/styles/theme/foundations/fonts.ts
+++ b/styles/theme/foundations/fonts.ts
@@ -1,6 +1,4 @@
-const fonts = {
+export const fonts = {
   body: `"Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif`,
   heading: `'Happiness-Sans'`,
 };
-
-export default fonts;

--- a/styles/theme/foundations/index.ts
+++ b/styles/theme/foundations/index.ts
@@ -1,4 +1,11 @@
-export { default as colors } from './colors';
-export { default as fonts } from './fonts';
-export { default as semanticTokens } from './semanticTokens';
-export { default as textStyles } from './textStyles';
+import { colors } from './colors';
+import { fonts } from './fonts';
+import { semanticTokens } from './semanticTokens';
+import { textStyles } from './textStyles';
+
+export const foundations = {
+  colors,
+  fonts,
+  semanticTokens,
+  textStyles,
+};

--- a/styles/theme/foundations/semanticTokens.ts
+++ b/styles/theme/foundations/semanticTokens.ts
@@ -1,4 +1,4 @@
-const semanticTokens = {
+export const semanticTokens = {
   colors: {
     error: 'red.1',
     success: 'green.1',
@@ -7,5 +7,3 @@ const semanticTokens = {
     disabled: 'grey.3',
   },
 };
-
-export default semanticTokens;

--- a/styles/theme/foundations/textStyles.ts
+++ b/styles/theme/foundations/textStyles.ts
@@ -1,4 +1,4 @@
-const textStyles = {
+export const textStyles = {
   h1: {
     fontStyle: 'normal',
     fontWeight: 600,
@@ -93,5 +93,3 @@ const textStyles = {
     color: '#FF6F1E',
   },
 };
-
-export default textStyles;

--- a/styles/theme/index.ts
+++ b/styles/theme/index.ts
@@ -4,7 +4,7 @@ import { extendTheme, type ThemeConfig } from '@chakra-ui/react';
 import styles from './styles';
 
 // Foundations
-import * as foundations from './foundations';
+import { foundations } from './foundations';
 
 const config: ThemeConfig = {
   initialColorMode: 'light',
@@ -32,6 +32,8 @@ const theme = extendTheme({
     },
   },
 });
-type Theme = typeof theme;
+
+type Theme = typeof theme & typeof foundations;
+
 export type { Theme };
 export default theme;


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#88

### 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용

- theme 사용방식을 일원화 했습니다
- theme import 시 타입 추론 되도록 수정했습니다.
  - 모듈 한번에 가져오면(`import * as xxx from '...'`) 어떤 타입인지 추론이 안되더라구요
  - 그래서 개별로(`import { xxx } from '...'`) 가져오는 방식으로 바꿨습니다. 