### PR TITLE
fix: theme 타입 추론 수정

### DIFF
--- a/styles/theme/index.ts
+++ b/styles/theme/index.ts
@@ -1,4 +1,5 @@
-import { extendTheme, type ThemeConfig } from '@chakra-ui/react';
+import type { Theme as ChakraTheme, ThemeConfig } from '@chakra-ui/react';
+import { extendTheme } from '@chakra-ui/react';
 
 // Global styles (overrides)
 import styles from './styles';
@@ -31,9 +32,9 @@ const theme = extendTheme({
       },
     },
   },
-});
+}) as Theme;
 
-type Theme = typeof theme & typeof foundations;
+type Theme = ChakraTheme & typeof foundations;
 
 export type { Theme };
 export default theme;


### PR DESCRIPTION
### 이슈 번호

closed Nexters/ditto#88

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

- `theme` 변수가 여전히 `Record<string, any>`로 추론되기에 
- `type Theme = ChakraTheme & typeof foundations`로 하고 type assertion 했습니다.
- as is
- <img width="443" alt="스크린샷 2023-02-25 오후 7 27 34" src="https://user-images.githubusercontent.com/22021344/221351976-ba7f279c-acd9-4194-b25e-dc551d363de0.png">
- to be
- <img width="380" alt="스크린샷 2023-02-25 오후 7 27 50" src="https://user-images.githubusercontent.com/22021344/221351979-afef012e-0a2c-4faf-ae77-443db8af5c21.png">
