### PR TITLE
fix: prod에서 프로필 사진 안보이는 이슈 수정

### DIFF
--- a/components/memberList/MemberItem.tsx
+++ b/components/memberList/MemberItem.tsx
@@ -1,6 +1,5 @@
 import theme from '@/styles/theme';
 import styled from '@emotion/styled';
-import Image from 'next/image';
 
 export type MemberItemProps = {
   nickname: string;
@@ -24,7 +23,7 @@ const MemberItemWrap = styled.div`
   padding: 10px 0 12px;
   border-bottom: 1px solid ${theme.colors.grey[2]};
 `;
-const MemberItemProfileImage = styled(Image)`
+const MemberItemProfileImage = styled.img`
   width: 48px;
   height: 48px;
   margin-right: 16px;


### PR DESCRIPTION
### 이슈 번호

closed Nexters/ditto#96

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

<img width="1792" alt="스크린샷 2023-02-26 오전 12 38 52" src="https://user-images.githubusercontent.com/22021344/221366787-35191bbc-6b0c-46b3-afc8-04ffe36b2348.png">

- prod에서 프로필 사진이 안보이는데, 요청 url이 `.../next/_image?...` 더라구요
- 해당 url은 404 페이지가 떠서 이슈가 생긴 것 같습니다.
- 원인은 저희 배포 환경이 edge runtime 이다보니 nodejs runtime에선 되는게 안되는거 아닐까 싶구요
- 외부 링크에서 가져오는거라 image 태그를 써도 큰 문제 없을 것 같아 변경했습니다.