### PR TITLE
fix: 모바일웹에서 100vh로 인해 하단 일부가 숨어있는 이슈 수정

### DIFF
--- a/components/layouts/MainLayout.tsx
+++ b/components/layouts/MainLayout.tsx
@@ -26,7 +26,7 @@ const MainLayout = ({
 const MainContainer = styled.main`
   position: relative;
   max-width: 420px;
-  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
   margin: 0 auto;
 `;
 

--- a/hooks/shared/useCalcViewHeight.ts
+++ b/hooks/shared/useCalcViewHeight.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export const useCalcViewHeight = () => {
+  useEffect(() => {
+    const setViewHeight = () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    };
+    window.addEventListener('resize', setViewHeight);
+    setViewHeight();
+
+    return () => {
+      window.removeEventListener('resize', setViewHeight);
+    };
+  }, []);
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from '@/components/errors/ErrorBoundary';
 import { useProtectedRoute } from '@/hooks/useProtectedRoute';
 import { SplashPage } from '@/components/loading/SplashPage';
 import Fonts from '@/styles/Font';
+import { useCalcViewHeight } from '@/hooks/shared/useCalcViewHeight';
 
 export type NextPageWithLayout<P = object, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -23,6 +24,8 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
   const [queryClient] = useState(() => new QueryClient());
   const getLayout = Component.getLayout ?? ((page) => page);
   const { showLoadingPage } = useProtectedRoute(Component?.isProtectedPage, '/');
+
+  useCalcViewHeight();
 
   return (
     <>


### PR DESCRIPTION
### 이슈 번호

closed Nexters/ditto#98

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

<img src="https://user-images.githubusercontent.com/22021344/221367752-7e5838c7-2d42-402a-a705-ed228cd6bb83.jpeg" width="300" />

- 모바일웹에서 화면 하단이 잘려보이는 현상을 수정합니다.
- 아래 글을 참고했습니다.
- https://jmjmjm.tistory.com/126