### PR TITLE
refactor: 페이지 전반적인 마크업 수정

### DIFF
--- a/components/bucketFolder/BucketFolderList.tsx
+++ b/components/bucketFolder/BucketFolderList.tsx
@@ -40,7 +40,6 @@ const StyledList = styled.ul`
   flex-direction: column;
   gap: 10px;
   padding: 16px 20px;
-  overflow: auto;
 `;
 
 const AddFolderButton = styled(Button)`

--- a/components/bucketFolder/BucketFolderList.tsx
+++ b/components/bucketFolder/BucketFolderList.tsx
@@ -15,26 +15,21 @@ const BucketFolderList = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   if (isError) return <div>에러 발생</div>;
+  if (isLoading) return <PartialLoader />;
 
   const emptyDataLength = MAX_LIST_LENGTH - data?.length;
 
   return (
     <StyledList>
-      {isLoading ? (
-        <PartialLoader />
-      ) : (
-        <>
-          {data?.slice(0, MAX_LIST_LENGTH).map((folder: BucketFolder) => (
-            <BucketFolderItem folder={folder} key={folder.id} />
-          ))}
-          {emptyDataLength > 0 &&
-            Array.from({ length: emptyDataLength }).map((_, index) => (
-              <li key={index}>
-                <AddFolderButton onClick={onOpen}>+</AddFolderButton>
-              </li>
-            ))}
-        </>
-      )}
+      {data?.slice(0, MAX_LIST_LENGTH).map((folder: BucketFolder) => (
+        <BucketFolderItem folder={folder} key={folder.id} />
+      ))}
+      {emptyDataLength > 0 &&
+        Array.from({ length: emptyDataLength }).map((_, index) => (
+          <li key={index}>
+            <AddFolderButton onClick={onOpen}>+</AddFolderButton>
+          </li>
+        ))}
       <AddBucketFolderModal isOpen={isOpen} onClose={onClose} />
     </StyledList>
   );
@@ -43,10 +38,9 @@ const BucketFolderList = () => {
 const StyledList = styled.ul`
   display: flex;
   flex-direction: column;
-  height: 100%;
-  min-height: calc(100vh - 230px);
   gap: 10px;
   padding: 16px 20px;
+  overflow: auto;
 `;
 
 const AddFolderButton = styled(Button)`

--- a/components/header/BucketlistHeader.tsx
+++ b/components/header/BucketlistHeader.tsx
@@ -1,0 +1,6 @@
+import { FlagIcon } from '../icons';
+import CommonHeader from './CommonHeader';
+
+export const BucketlistHeader = () => {
+  return <CommonHeader title="버킷리스트" icon={<FlagIcon />} />;
+};

--- a/components/header/CommonHeader.tsx
+++ b/components/header/CommonHeader.tsx
@@ -1,42 +1,52 @@
+import theme from '@/styles/theme';
+import { Heading } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
+import GroupMenu from '../groupMenu/GroupMenu';
 
 interface CommonHeaderProps {
-  children: ReactNode;
+  title: string;
+  icon: ReactNode;
 }
 
-const CommonHeader = ({ children }: CommonHeaderProps) => {
-  return <CommonHeaderContainer>{children}</CommonHeaderContainer>;
+export const COMMON_HEADER_HEIGHT = 94;
+
+const CommonHeader = ({ title, icon }: CommonHeaderProps) => {
+  return (
+    <CommonHeaderContainer>
+      <LeftContainer>
+        <GroupMenu />
+        <Heading fontSize={'24px'} lineHeight={1} fontWeight={700} letterSpacing={-0.02}>
+          {title}
+        </Heading>
+      </LeftContainer>
+
+      <RightContainer>{icon}</RightContainer>
+    </CommonHeaderContainer>
+  );
 };
 
-const Left = ({ children }: CommonHeaderProps) => {
-  return <LeftContainer>{children}</LeftContainer>;
-};
-
-const Right = ({ children }: CommonHeaderProps) => {
-  return <RightContainer>{children}</RightContainer>;
-};
-
-export default Object.assign(CommonHeader, {
-  Left,
-  Right,
-});
+export default CommonHeader;
 
 const CommonHeaderContainer = styled.header`
-  position: absolute;
-  top: 0;
+  width: 100%;
+  height: ${COMMON_HEADER_HEIGHT}px;
+
   display: flex;
   justify-content: space-between;
-  width: 100%;
-  max-width: 420px;
+  align-items: center;
+
+  padding: 20px;
   background-color: #fff;
-  padding: 17px 20px;
-  z-index: 10;
+  border-bottom: 1px solid ${theme.colors.grey[2]};
 `;
 
 const LeftContainer = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 14px;
 `;
 
 const RightContainer = styled.div``;

--- a/components/header/EventHeader.tsx
+++ b/components/header/EventHeader.tsx
@@ -1,20 +1,9 @@
 import React from 'react';
-import GroupMenu from '../groupMenu/GroupMenu';
 import { CalendarIcon } from '../icons';
 import CommonHeader from './CommonHeader';
 
 const EventHeader = () => {
-  return (
-    <CommonHeader>
-      <CommonHeader.Left>
-        <GroupMenu />
-        <h1>일정</h1>
-      </CommonHeader.Left>
-      <CommonHeader.Right>
-        <CalendarIcon />
-      </CommonHeader.Right>
-    </CommonHeader>
-  );
+  return <CommonHeader title="일정" icon={<CalendarIcon />} />;
 };
 
 export default EventHeader;

--- a/components/header/MyPageHeader.tsx
+++ b/components/header/MyPageHeader.tsx
@@ -1,0 +1,30 @@
+import theme from '@/styles/theme';
+import styled from '@emotion/styled';
+import GroupMenu from '../groupMenu/GroupMenu';
+
+export const MY_PAGE_HEADER_HEIGHT = 58;
+
+export const MyPageHeader = () => {
+  return (
+    <MyPageHeaderWrap>
+      My page
+      <GroupMenu />
+    </MyPageHeaderWrap>
+  );
+};
+
+const MyPageHeaderWrap = styled.h1`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  height: ${MY_PAGE_HEADER_HEIGHT}px;
+  padding: 0 20px;
+  ${theme.textStyles.h3};
+  border-bottom: 1px solid ${theme.colors.grey[2]};
+`;

--- a/components/icons/ArrowRightIcon.tsx
+++ b/components/icons/ArrowRightIcon.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 import { SVGProps } from 'react';
 const SvgArrowRightIcon = (props: SVGProps<SVGSVGElement>) => (
-  <svg width={32} height={32} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-    <path d="M5 16h22m-9-9 9 9-9 9" stroke="#1E1F20" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+  <svg width={28} height={28} viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M23.625 14H4.375m7.875 7.875L4.375 14l7.875-7.875"
+      stroke="#1E1F20"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 );
 export default SvgArrowRightIcon;

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -1,3 +1,4 @@
+export { default as ArrowRightIcon } from './ArrowRightIcon';
 export { default as ArrowRightIcon20 } from './ArrowRightIcon20';
 export { default as ArrowRightIcon32 } from './ArrowRightIcon32';
 export { default as BlackDownIcon } from './BlackDownIcon';

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
+import ArrowRightIcon from '../icons/ArrowRightIcon';
 
 const PageHeader = ({ useBackButton = false }: { useBackButton?: boolean }) => {
   const router = useRouter();
@@ -8,12 +9,25 @@ const PageHeader = ({ useBackButton = false }: { useBackButton?: boolean }) => {
     router.back();
   };
 
-  return <Header>{useBackButton && <button onClick={handleBack}>←</button>}</Header>;
+  return (
+    <Header>
+      {useBackButton && (
+        <BackButton onClick={handleBack}>
+          <ArrowRightIcon width={28} height={28} rotate={'1'} />
+        </BackButton>
+      )}
+    </Header>
+  );
 };
 
-const Header = styled.div`
+const Header = styled.header`
+  width: 100%;
+  height: 42px;
   display: flex;
-  height: 60px;
+  justify-content: flex-start;
   align-items: center;
+  padding: 0 16px;
 `;
+const BackButton = styled.button``;
+
 export default PageHeader;

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -2,7 +2,9 @@ import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import ArrowRightIcon from '../icons/ArrowRightIcon';
 
-const PageHeader = ({ useBackButton = false }: { useBackButton?: boolean }) => {
+export const PAGE_HEADER_HEIGHT = 42;
+
+const PageHeader = () => {
   const router = useRouter();
 
   const handleBack = () => {
@@ -11,18 +13,16 @@ const PageHeader = ({ useBackButton = false }: { useBackButton?: boolean }) => {
 
   return (
     <Header>
-      {useBackButton && (
-        <BackButton onClick={handleBack}>
-          <ArrowRightIcon width={28} height={28} rotate={'1'} />
-        </BackButton>
-      )}
+      <BackButton onClick={handleBack}>
+        <ArrowRightIcon width={28} height={28} rotate={'1'} />
+      </BackButton>
     </Header>
   );
 };
 
 const Header = styled.header`
   width: 100%;
-  height: 42px;
+  height: ${PAGE_HEADER_HEIGHT}px;
   display: flex;
   justify-content: flex-start;
   align-items: center;

--- a/components/layouts/MainLayout.tsx
+++ b/components/layouts/MainLayout.tsx
@@ -1,22 +1,23 @@
 import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import BottomNavigation, { BottomNavBarHeight } from './BottomNavigation';
+import theme from '@/styles/theme';
+import { COMMON_HEADER_HEIGHT } from '../header/CommonHeader';
 
-const MainLayout = ({
-  children,
-  header,
-  floatButton,
-  hideBottomNavigation = false,
-}: {
+type MainLayoutProps = {
   children: ReactNode;
   header?: ReactNode;
   floatButton?: ReactNode;
   hideBottomNavigation?: boolean;
-}) => {
+};
+
+const MainLayout = ({ children, header, floatButton, hideBottomNavigation = false }: MainLayoutProps) => {
   return (
     <MainContainer>
       {header}
-      <MainSection hideBottomNavigation={hideBottomNavigation}>{children}</MainSection>
+      <MainSection hasHeader={!!header} hideBottomNavigation={hideBottomNavigation}>
+        {children}
+      </MainSection>
       {floatButton && <FloatButtonContainer>{floatButton}</FloatButtonContainer>}
       {!hideBottomNavigation && <BottomNavigation />}
     </MainContainer>
@@ -30,13 +31,14 @@ const MainContainer = styled.main`
   margin: 0 auto;
 `;
 
-const MainSection = styled.section<{ hideBottomNavigation?: boolean }>`
+const MainSection = styled.section<{ hasHeader?: boolean; hideBottomNavigation?: boolean }>`
   position: absolute;
-  top: 0;
+  top: ${(props) => (props.hasHeader ? COMMON_HEADER_HEIGHT : 0)}px;
   left: 0;
   right: 0;
   bottom: ${(props) => (props.hideBottomNavigation ? 0 : BottomNavBarHeight)}px;
   overflow: auto;
+  background-color: ${theme.colors.grey[1]};
 `;
 
 const FloatButtonContainer = styled.div`

--- a/components/layouts/MainLayout.tsx
+++ b/components/layouts/MainLayout.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import BottomNavigation, { BottomNavBarHeight } from './BottomNavigation';
-import theme from '@/styles/theme';
 import { COMMON_HEADER_HEIGHT } from '../header/CommonHeader';
 
 type MainLayoutProps = {
@@ -38,7 +37,6 @@ const MainSection = styled.section<{ hasHeader?: boolean; hideBottomNavigation?:
   right: 0;
   bottom: ${(props) => (props.hideBottomNavigation ? 0 : BottomNavBarHeight)}px;
   overflow: auto;
-  background-color: ${theme.colors.grey[1]};
 `;
 
 const FloatButtonContainer = styled.div`

--- a/components/layouts/MainLayout.tsx
+++ b/components/layouts/MainLayout.tsx
@@ -1,20 +1,26 @@
 import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import BottomNavigation, { BottomNavBarHeight } from './BottomNavigation';
-import { COMMON_HEADER_HEIGHT } from '../header/CommonHeader';
 
 type MainLayoutProps = {
   children: ReactNode;
   header?: ReactNode;
+  headerHeight?: number;
   floatButton?: ReactNode;
   hideBottomNavigation?: boolean;
 };
 
-const MainLayout = ({ children, header, floatButton, hideBottomNavigation = false }: MainLayoutProps) => {
+const MainLayout = ({
+  children,
+  header,
+  headerHeight = 0,
+  floatButton,
+  hideBottomNavigation = false,
+}: MainLayoutProps) => {
   return (
     <MainContainer>
       {header}
-      <MainSection hasHeader={!!header} hideBottomNavigation={hideBottomNavigation}>
+      <MainSection headerHeight={headerHeight} bottomNavHeight={hideBottomNavigation ? 0 : BottomNavBarHeight}>
         {children}
       </MainSection>
       {floatButton && <FloatButtonContainer>{floatButton}</FloatButtonContainer>}
@@ -30,12 +36,12 @@ const MainContainer = styled.main`
   margin: 0 auto;
 `;
 
-const MainSection = styled.section<{ hasHeader?: boolean; hideBottomNavigation?: boolean }>`
+const MainSection = styled.section<{ headerHeight: number; bottomNavHeight: number }>`
   position: absolute;
-  top: ${(props) => (props.hasHeader ? COMMON_HEADER_HEIGHT : 0)}px;
+  top: ${(props) => props.headerHeight}px;
   left: 0;
   right: 0;
-  bottom: ${(props) => (props.hideBottomNavigation ? 0 : BottomNavBarHeight)}px;
+  bottom: ${(props) => props.bottomNavHeight}px;
   overflow: auto;
 `;
 

--- a/components/layouts/SimpleHeader.tsx
+++ b/components/layouts/SimpleHeader.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import ArrowRightIcon from '../icons/ArrowRightIcon';
 
-export const PAGE_HEADER_HEIGHT = 42;
+export const SIMPLE_HEADER_HEIGHT = 42;
 
-const PageHeader = () => {
+const SimpleHeader = () => {
   const router = useRouter();
 
   const handleBack = () => {
@@ -12,17 +12,17 @@ const PageHeader = () => {
   };
 
   return (
-    <Header>
+    <HeaderWrap>
       <BackButton onClick={handleBack}>
         <ArrowRightIcon width={28} height={28} rotate={'1'} />
       </BackButton>
-    </Header>
+    </HeaderWrap>
   );
 };
 
-const Header = styled.header`
+const HeaderWrap = styled.header`
   width: 100%;
-  height: ${PAGE_HEADER_HEIGHT}px;
+  height: ${SIMPLE_HEADER_HEIGHT}px;
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -30,4 +30,4 @@ const Header = styled.header`
 `;
 const BackButton = styled.button``;
 
-export default PageHeader;
+export default SimpleHeader;

--- a/components/modals/BaseModal.tsx
+++ b/components/modals/BaseModal.tsx
@@ -15,7 +15,7 @@ const BaseModal = (props: BaseModalProps) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} closeOnOverlayClick={closeOnOverlayClick}>
       <ModalOverlay bg="blackAlpha.700" />
-      <ModalContent bgColor="white" boxShadow="none" marginTop={138} width={width || 300} height={height || 230}>
+      <ModalContent bgColor="white" width={width || 300} height={height || 230}>
         {modalContent}
       </ModalContent>
     </Modal>

--- a/pages/bucketlist/[folderId].tsx
+++ b/pages/bucketlist/[folderId].tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NextPageWithLayout } from '@/pages/_app';
-import PageHeader, { PAGE_HEADER_HEIGHT } from '@/components/layouts/Header';
+import SimpleHeader, { SIMPLE_HEADER_HEIGHT } from '@/components/layouts/SimpleHeader';
 import MainLayout from '@/components/layouts/MainLayout';
 import BucketItemList from '@/components/bucketItem/BucketItemList';
 import { Text } from '@chakra-ui/react';
@@ -16,7 +16,7 @@ const BucketListItem: NextPageWithLayout = () => {
   const { data } = useFetchBucketFolderById(Number(folderId));
 
   return (
-    <MainLayout header={<PageHeader />} headerHeight={PAGE_HEADER_HEIGHT}>
+    <MainLayout header={<SimpleHeader />} headerHeight={SIMPLE_HEADER_HEIGHT}>
       <ListWrapper>
         <Text textStyle={'h1'} marginBottom={'12px'} minHeight={'105px'}>
           {data?.title}

--- a/pages/bucketlist/[folderId].tsx
+++ b/pages/bucketlist/[folderId].tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NextPageWithLayout } from '@/pages/_app';
-import PageHeader from '@/components/layouts/Header';
+import PageHeader, { PAGE_HEADER_HEIGHT } from '@/components/layouts/Header';
 import MainLayout from '@/components/layouts/MainLayout';
 import BucketItemList from '@/components/bucketItem/BucketItemList';
 import { Text } from '@chakra-ui/react';
@@ -16,7 +16,7 @@ const BucketListItem: NextPageWithLayout = () => {
   const { data } = useFetchBucketFolderById(Number(folderId));
 
   return (
-    <>
+    <MainLayout header={<PageHeader />} headerHeight={PAGE_HEADER_HEIGHT}>
       <ListWrapper>
         <Text textStyle={'h1'} marginBottom={'12px'} minHeight={'105px'}>
           {data?.title}
@@ -24,16 +24,9 @@ const BucketListItem: NextPageWithLayout = () => {
         <ConditionalRabbitIcon folderTitle={data?.title ?? ''} />
         <BucketItemList />
       </ListWrapper>
-    </>
+    </MainLayout>
   );
 };
-
-BucketListItem.getLayout = (page) => (
-  <MainLayout>
-    <PageHeader useBackButton />
-    {page}
-  </MainLayout>
-);
 
 BucketListItem.isProtectedPage = true;
 

--- a/pages/bucketlist/index.tsx
+++ b/pages/bucketlist/index.tsx
@@ -1,41 +1,17 @@
 import React from 'react';
-import PageHeader from '@/components/layouts/Header';
 import MainLayout from '@/components/layouts/MainLayout';
 import { NextPageWithLayout } from '@/pages/_app';
 import BucketFolderList from '@/components/bucketFolder/BucketFolderList';
-import { FlagIcon } from '@/components/icons';
-import { Box, Divider, Text } from '@chakra-ui/react';
-import styled from '@emotion/styled';
+import { BucketlistHeader } from '@/components/header/BucketlistHeader';
 
 const BucketList: NextPageWithLayout = () => {
   return (
-    <>
-      <StyledHeader>
-        <Text textStyle={'h2'} alignSelf={'flex-end'}>
-          버킷리스트
-        </Text>
-        <FlagIcon />
-      </StyledHeader>
-      <Box bg={'grey.1'}>
-        <Divider borderColor={'divider'} marginTop={'20px'} />
-        <BucketFolderList />
-      </Box>
-    </>
+    <MainLayout header={<BucketlistHeader />}>
+      <BucketFolderList />
+    </MainLayout>
   );
 };
 
-const StyledHeader = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-BucketList.getLayout = (page) => (
-  <MainLayout>
-    <PageHeader />
-    {page}
-  </MainLayout>
-);
 BucketList.isProtectedPage = true;
 
 export default BucketList;

--- a/pages/bucketlist/index.tsx
+++ b/pages/bucketlist/index.tsx
@@ -3,11 +3,15 @@ import MainLayout from '@/components/layouts/MainLayout';
 import { NextPageWithLayout } from '@/pages/_app';
 import BucketFolderList from '@/components/bucketFolder/BucketFolderList';
 import { BucketlistHeader } from '@/components/header/BucketlistHeader';
+import styled from '@emotion/styled';
+import theme from '@/styles/theme';
 
 const BucketList: NextPageWithLayout = () => {
   return (
     <MainLayout header={<BucketlistHeader />}>
-      <BucketFolderList />
+      <ListContainer>
+        <BucketFolderList />
+      </ListContainer>
     </MainLayout>
   );
 };
@@ -15,3 +19,9 @@ const BucketList: NextPageWithLayout = () => {
 BucketList.isProtectedPage = true;
 
 export default BucketList;
+
+const ListContainer = styled.section`
+  height: 100%;
+  overflow: auto;
+  background-color: ${theme.colors.grey[1]};
+`;

--- a/pages/bucketlist/index.tsx
+++ b/pages/bucketlist/index.tsx
@@ -5,10 +5,11 @@ import BucketFolderList from '@/components/bucketFolder/BucketFolderList';
 import { BucketlistHeader } from '@/components/header/BucketlistHeader';
 import styled from '@emotion/styled';
 import theme from '@/styles/theme';
+import { COMMON_HEADER_HEIGHT } from '@/components/header/CommonHeader';
 
 const BucketList: NextPageWithLayout = () => {
   return (
-    <MainLayout header={<BucketlistHeader />}>
+    <MainLayout header={<BucketlistHeader />} headerHeight={COMMON_HEADER_HEIGHT}>
       <ListContainer>
         <BucketFolderList />
       </ListContainer>

--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -11,6 +11,7 @@ import { dateChangeToEventFormat } from '@/utils/date';
 import { useFetchEventList } from '@/hooks/Event/useFetchEventList';
 import { useUser } from '@/store/useUser';
 import useChangeMode from '@/store/useChangeMode';
+import { COMMON_HEADER_HEIGHT } from '@/components/header/CommonHeader';
 
 const Event: NextPageWithLayout = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -29,6 +30,7 @@ const Event: NextPageWithLayout = () => {
   return (
     <MainLayout
       header={<EventHeader />}
+      headerHeight={COMMON_HEADER_HEIGHT}
       floatButton={
         <Button
           width="64px"

--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -78,6 +78,9 @@ const ListContainer = styled.ul`
   flex-direction: column;
   gap: 8px;
   padding: 12px 20px 80px;
+  height: 100%;
+  overflow: auto;
+  background-color: ${theme.colors.grey[1]};
 `;
 
 const ListItem = styled.li`

--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -77,7 +77,7 @@ const ListContainer = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 12px 20px;
+  padding: 12px 20px 80px;
 `;
 
 const ListItem = styled.li`

--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -12,15 +12,13 @@ import { useFetchEventList } from '@/hooks/Event/useFetchEventList';
 import { useUser } from '@/store/useUser';
 import useChangeMode from '@/store/useChangeMode';
 
-const EVENT_HEADER_HEIGHT = 98;
-
 const Event: NextPageWithLayout = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { selectedGroupId } = useUser();
   const { data } = useFetchEventList(Number(selectedGroupId), {
     enabled: !!selectedGroupId,
   });
-  
+
   const { setMode } = useChangeMode();
 
   const handleClickEvent = (id: number) => () => {
@@ -44,29 +42,28 @@ const Event: NextPageWithLayout = () => {
         </Button>
       }
     >
-      <Flex marginTop={`${EVENT_HEADER_HEIGHT}px`} minHeight="100%" width="100%" backgroundColor={theme.colors.grey[1]}>
-        <ListContainer>
-          {/* TODO: 등록된 일정 없을떄의 화면 추가되어야함 */}
-          {data?.map(
-            ({ id, title, start_time: startTime, end_time: endTime, is_all_day: isAllDay, is_annual: isAnnual }) => (
-              <ListItem key={id} onClick={handleClickEvent(id)}>
-                <Flex flexDirection="column" gap="8px">
-                  <Text textStyle="buttonMedium" color={theme.colors.secondary}>
-                    {title}
-                  </Text>
-                  <Text textStyle="body3" fontWeight={500} color={theme.colors.grey[4]}>
-                    {dateChangeToEventFormat(startTime, endTime)}
-                  </Text>
-                </Flex>
-                <Flex>
-                  {isAllDay ? <Chip type="allDay">오늘</Chip> : null}
-                  {isAnnual ? <Chip type="annual">매년</Chip> : null}
-                </Flex>
-              </ListItem>
-            )
-          )}
-        </ListContainer>
-      </Flex>
+      <ListContainer>
+        {/* TODO: 등록된 일정 없을떄의 화면 추가되어야함 */}
+        {data?.map(
+          ({ id, title, start_time: startTime, end_time: endTime, is_all_day: isAllDay, is_annual: isAnnual }) => (
+            <ListItem key={id} onClick={handleClickEvent(id)}>
+              <Flex flexDirection="column" gap="8px">
+                <Text textStyle="buttonMedium" color={theme.colors.secondary}>
+                  {title}
+                </Text>
+                <Text textStyle="body3" fontWeight={500} color={theme.colors.grey[4]}>
+                  {dateChangeToEventFormat(startTime, endTime)}
+                </Text>
+              </Flex>
+              <Flex>
+                {isAllDay ? <Chip type="allDay">오늘</Chip> : null}
+                {isAnnual ? <Chip type="annual">매년</Chip> : null}
+              </Flex>
+            </ListItem>
+          )
+        )}
+      </ListContainer>
+
       <EventModal isOpen={isOpen} onClose={onClose} />
     </MainLayout>
   );
@@ -80,8 +77,6 @@ const ListContainer = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  width: 100%;
-  height: 100%;
   padding: 12px 20px;
 `;
 

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,4 +1,4 @@
-import GroupMenu from '@/components/groupMenu/GroupMenu';
+import { MyPageHeader, MY_PAGE_HEADER_HEIGHT } from '@/components/header/MyPageHeader';
 import MainLayout from '@/components/layouts/MainLayout';
 import { MemberList } from '@/components/memberList/MemberList';
 import CreateGroupModal from '@/components/modals/CreateGroupModal';
@@ -18,18 +18,12 @@ const MyPage: NextPageWithLayout = () => {
   };
 
   return (
-    <MainLayout>
-      <MyPageHeader>
-        My page
-        <GroupMenu />
-      </MyPageHeader>
-      <MyPageContent>
-        <MemberList />
-        <MyPageDivider />
-        <OtherButton onClick={onOpen}>새 그룹 만들기</OtherButton>
-        <OtherButton onClick={goToOpenInquiryChannel}>문의하기</OtherButton>
-        <OtherButton onClick={logout}>로그아웃</OtherButton>
-      </MyPageContent>
+    <MainLayout header={<MyPageHeader />} headerHeight={MY_PAGE_HEADER_HEIGHT}>
+      <MemberList />
+      <MyPageDivider />
+      <OtherButton onClick={onOpen}>새 그룹 만들기</OtherButton>
+      <OtherButton onClick={goToOpenInquiryChannel}>문의하기</OtherButton>
+      <OtherButton onClick={logout}>로그아웃</OtherButton>
 
       <CreateGroupModal isOpen={isOpen} onClose={onClose} />
     </MainLayout>
@@ -40,29 +34,6 @@ MyPage.isProtectedPage = true;
 
 export default MyPage;
 
-const MyPageHeader = styled.h1`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  height: 58px;
-  padding: 0 20px;
-  ${theme.textStyles.h3};
-  border-bottom: 1px solid ${theme.colors.grey[2]};
-`;
-const MyPageContent = styled.section`
-  position: absolute;
-  top: 58px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  overflow: auto;
-`;
 const MyPageDivider = styled.div`
   width: 100%;
   height: 6px;

--- a/public/assets/ArrowRightIcon.svg
+++ b/public/assets/ArrowRightIcon.svg
@@ -1,0 +1,4 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.625 14L4.375 14" stroke="#1E1F20" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.25 21.875L4.375 14L12.25 6.125" stroke="#1E1F20" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#

### 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용


https://user-images.githubusercontent.com/22021344/221889183-310b6bdd-6432-4e0f-9479-b04fc29d728b.mov

- 페이지 전반적으로 마크업 수정을 했습니다.
  - 하다보니 getLayout 사용을 제거하게 되었습니다
- CommonHeader 구조를 좀 더 재활용 쉽게 변경했습니다.
- MainLayout 구조를 재활용 용이하게 header height도 반영할 수 있도록 변경했습니다.
- BaseModal이 모바일웹에서 볼 때는 margin top이 불필요하다고 생각되어 없앴습니다.
