### PR TITLE
refactor: QueryClient에 기본 옵션 추가

### DIFF
--- a/hooks/Event/useFetchEvent.ts
+++ b/hooks/Event/useFetchEvent.ts
@@ -12,7 +12,6 @@ export const useFetchEventById = (eventId: number, options?: UseQueryOptions<Eve
     },
     {
       ...options,
-      staleTime: Infinity,
     }
   );
 };

--- a/hooks/Event/useFetchEventList.ts
+++ b/hooks/Event/useFetchEventList.ts
@@ -12,7 +12,6 @@ export const useFetchEventList = (currentGroupId: number, options?: UseQueryOpti
     },
     {
       ...options,
-      staleTime: Infinity,
     }
   );
 };

--- a/hooks/bucketlist/useFetchBucketFolderById.ts
+++ b/hooks/bucketlist/useFetchBucketFolderById.ts
@@ -10,6 +10,5 @@ export const useFetchBucketFolderById = (id: number) => {
   };
   return useQuery<BucketFolder, Error>(BUCKET_FOLDER_KEY.detail([id]), fetcher, {
     enabled: !!id,
-    staleTime: Infinity,
   });
 };

--- a/hooks/bucketlist/useFetchBucketFolders.ts
+++ b/hooks/bucketlist/useFetchBucketFolders.ts
@@ -13,9 +13,5 @@ export const useFetchBucketFolders = () => {
     const response = await getBucketFolders(selectedGroupId);
     return response;
   };
-  return useQuery<BucketFolder[], Error>(BUCKET_FOLDER_KEY.list([selectedGroupId]), fetcher, {
-    refetchOnMount: false,
-    keepPreviousData: true,
-    staleTime: Infinity,
-  });
+  return useQuery<BucketFolder[], Error>(BUCKET_FOLDER_KEY.list([selectedGroupId]), fetcher);
 };

--- a/hooks/bucketlist/useFetchBucketItems.ts
+++ b/hooks/bucketlist/useFetchBucketItems.ts
@@ -10,8 +10,5 @@ export const useFetchBucketItems = (folderId: number) => {
   };
   return useQuery<BucketItem[], Error>(BUCKET_ITEM_KEY.list([folderId]), fetcher, {
     enabled: !!folderId,
-    refetchOnMount: false,
-    keepPreviousData: true,
-    staleTime: Infinity,
   });
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,7 +22,22 @@ type AppPropsWithLayout = AppProps & {
 };
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
-  const [queryClient] = useState(() => new QueryClient());
+  // ref: https://tech.kakao.com/2022/06/13/react-query/
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            useErrorBoundary: true,
+            retry: 0,
+            refetchOnMount: false,
+          },
+          mutations: {
+            useErrorBoundary: true,
+          },
+        },
+      })
+  );
   const getLayout = Component.getLayout ?? ((page) => page);
   const { showLoadingPage } = useProtectedRoute(Component?.isProtectedPage, '/');
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -31,6 +31,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
             useErrorBoundary: true,
             retry: 0,
             refetchOnMount: false,
+            keepPreviousData: true,
           },
           mutations: {
             useErrorBoundary: true,


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#

### 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용

- 개별 쿼리에 설정되던 옵션들을 중앙에서 관리하고자 기본 옵션으로 변경했습니다.
- `staleTime: Infinity`는 리액트 쿼리에서 자동으로 갱신하는 모든 로직을 무시하는 거다보니 꼭 그럴 필요는 없는 것 같아 일단 없앴습니다.
- 개별 쿼리에 꼭 필요한 것들이 있다면 말씀해주시면 감사하겠습니다용 🙇‍♂️