### PR TITLE
fix: heading 글씨 크기 맘대로 변경되는거 수정

### DIFF
--- a/components/modals/InviteMemberModal.tsx
+++ b/components/modals/InviteMemberModal.tsx
@@ -43,7 +43,7 @@ const ModalContent = () => {
 
   return (
     <ModalBody textAlign={'center'}>
-      <ShareInvitationTitle>
+      <ShareInvitationTitle fontSize={'18px'} lineHeight={'1.5'}>
         <b>{group?.name}</b>의 <br />
         새로운 멤버를 초대해보세요
       </ShareInvitationTitle>
@@ -71,8 +71,6 @@ export default InviteMemberModal;
 const ShareInvitationTitle = styled(Heading)`
   margin: 20px 0 30px;
   font-weight: 400;
-  font-size: 18px;
-  line-height: 27px;
   text-align: center;
   letter-spacing: -0.01em;
   color: ${theme.colors.grey[10]};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -71,7 +71,7 @@ const RootPage = () => {
   return (
     <MainLayout hideBottomNavigation>
       <Container>
-        <WelcomeMessage>
+        <WelcomeMessage fontSize={'36px'} lineHeight={'1.5'}>
           {invitationInfo ? (
             <>
               <b>{invitationInfo?.users.nickname}</b>님이
@@ -113,9 +113,7 @@ const Container = styled.section`
 `;
 const WelcomeMessage = styled(Heading)`
   padding: 56px 28px 0;
-  font-size: 36px;
   font-weight: 400;
-  line-height: 150%;
   letter-spacing: -0.02em;
   white-space: pre-line;
   text-align: left;


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

<img width="325" alt="스크린샷 2023-03-02 오전 12 42 57" src="https://user-images.githubusercontent.com/22021344/222205101-c46b43f0-0ea7-46ed-9101-448523300019.png">
👆 문제 원인

- heading에 fontsize, line-height를 props으로 주지 않으면
- 특정 스크린 사이즈 이상일때 기본 폰트 사이즈를 주입합니다...
- 이 현상을 방지하기 위해 폰트 사이즈를 props으로 넘겨줍니다.
- 제보 감사합니다 
