### PR TITLE
feat: 일정 생성, 수정, 삭제시 토스트 띄우기

### DIFF
--- a/hooks/Event/useCreateEvent.ts
+++ b/hooks/Event/useCreateEvent.ts
@@ -2,9 +2,11 @@ import { createEvent } from '@/lib/supabase/apis/event';
 import { CreateEventType } from '@/lib/supabase/apis/event/type';
 import { EVENT_KEY } from '@/utils/const';
 import { useMutation, useQueryClient, UseQueryOptions } from '@tanstack/react-query';
+import useCustomToast from '../shared/useCustomToast';
 
 export const useCreateEvent = (options?: UseQueryOptions<void, Error>) => {
   const queryClient = useQueryClient();
+  const { openToast } = useCustomToast();
   return useMutation(
     async (params: CreateEventType) => {
       await createEvent(params);
@@ -13,10 +15,10 @@ export const useCreateEvent = (options?: UseQueryOptions<void, Error>) => {
       onSuccess: (data) => {
         queryClient.invalidateQueries({ queryKey: EVENT_KEY.lists() });
         options?.onSuccess?.(data);
-        // TODO: 일정 추가 완료 토스트 띄우기
+        openToast({ message: '일정이 생성되었습니다.', type: 'success' });
       },
       onError: () => {
-        // TODO: 일정 추가 에러 토스트 띄우기
+        openToast({ message: '일정 생성에 실패했습니다. 화면을 새로고침해주세요', type: 'error' });
       },
     }
   );

--- a/hooks/Event/useDeleteEvent.ts
+++ b/hooks/Event/useDeleteEvent.ts
@@ -1,19 +1,21 @@
 import { deleteEvent } from '@/lib/supabase/apis/event';
 import { EVENT_KEY } from '@/utils/const';
 import { useQueryClient, useMutation, UseMutationOptions } from '@tanstack/react-query';
+import useCustomToast from '../shared/useCustomToast';
 
 export const useDeleteEvent = (options?: Omit<UseMutationOptions<void, Error, number>, 'mutationFn'>) => {
   const queryClient = useQueryClient();
+  const { openToast } = useCustomToast();
 
   return useMutation(async (eventId: number) => await deleteEvent(eventId), {
     ...options,
     onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({ queryKey: EVENT_KEY.lists() });
       options?.onSuccess?.(data, variables, context);
-      // TODO: 삭제 완료 토스트 띄우기
+      openToast({ message: '일정이 삭제되었습니다.', type: 'success' });
     },
     onError: () => {
-      // TODO: 삭제 에러 토스트 띄우기
+      openToast({ message: '일정 삭제에 실패했습니다. 화면을 새로고침해주세요', type: 'error' });
     },
   });
 };

--- a/hooks/Event/useUpdateEvent.ts
+++ b/hooks/Event/useUpdateEvent.ts
@@ -2,19 +2,21 @@ import { updateEvent } from '@/lib/supabase/apis/event';
 import { useQueryClient, useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { UpdateEventType } from '@/lib/supabase/apis/event/type';
 import { EVENT_KEY } from '@/utils/const';
+import useCustomToast from '../shared/useCustomToast';
 
 export const useUpdateEvent = (options?: Omit<UseMutationOptions<void, Error, UpdateEventType>, 'mutationFn'>) => {
   const queryClient = useQueryClient();
+  const { openToast } = useCustomToast();
 
   return useMutation(async (params: UpdateEventType) => await updateEvent(params), {
     ...options,
     onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({ queryKey: EVENT_KEY.lists() });
       options?.onSuccess?.(data, variables, context);
-      // TODO: 일정 수정 완료 토스트 띄우기
+      openToast({ message: '일정이 편집되었습니다.', type: 'success' });
     },
     onError: () => {
-      // TODO: 일정 수정 에러 토스트 띄우기
+      openToast({ message: '일정 편집에 실패했습니다. 화면을 새로고침해주세요', type: 'success' });
     },
   });
 };


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#117

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 일정 생성, 수정, 삭제시 토스트를 띄우도록 했습니다.