### PR TITLE
refactor: 오늘 날짜에 하루종일이 선택됐을 때 다가오는 일정에 포함되도록 수정

### DIFF
--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -38,9 +38,18 @@ const EventFilterMenuList = [
 ] as const;
 
 // 다가오는 일정
-const filterByComingEvent = (data: Event[]) => data?.filter((v) => differenceInMilisecondsFromNow(v.end_time) > 0);
+const filterByComingEvent = (data: Event[]) =>
+  data?.filter((v) => {
+    if (today(v.start_time, v.end_time) && v.is_all_day) return true;
+    return differenceInMilisecondsFromNow(v.end_time) > 0;
+  });
+
 // 지난 일정
-const filterByPastEvent = (data: Event[]) => data?.filter((v) => differenceInMilisecondsFromNow(v.end_time) <= 0);
+const filterByPastEvent = (data: Event[]) =>
+  data?.filter((v) => {
+    if (today(v.start_time, v.end_time) && v.is_all_day) return false;
+    return differenceInMilisecondsFromNow(v.end_time) <= 0;
+  });
 
 const Event: NextPageWithLayout = () => {
   const comingEvent = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 오늘 날짜에 하루종일이 선택됐을 때 다가오는 일정에 포함되도록 수정했습니다! 반대로 날짜가 오늘 포함에 하루종일이 선택된 상태면 지난일정에선 뺐습니다
