### PR TITLE
hotfix: 이벤트 생성시 필터탭 갱신되도록 수정

### DIFF
--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -88,9 +88,9 @@ const Event: NextPageWithLayout = () => {
   const resetFirstCreatedEvent = () => setFirstCreatedEvent(false);
 
   useEffect(() => {
-    if (eventList && isTriggerOnce) {
+    if (eventList) {
       setFilterEvent(filterByComingEvent(eventList ?? []));
-      setTriggerOnce(false);
+      if (isTriggerOnce) setTriggerOnce(false);
     }
   }, [eventList, isTriggerOnce]);
 

--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -89,7 +89,8 @@ const Event: NextPageWithLayout = () => {
 
   useEffect(() => {
     if (eventList) {
-      setFilterEvent(filterByComingEvent(eventList ?? []));
+      if (comingEvent.current?.checked) setFilterEvent(filterByComingEvent(eventList));
+      if (pastEvent.current?.checked) setFilterEvent(filterByPastEvent(eventList));
       if (isTriggerOnce) setTriggerOnce(false);
     }
   }, [eventList, isTriggerOnce]);


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 다가오는 일정에 포함되는 이벤트 생성시 일정에 바로 적용안되는 에러를 수정했습니다.