### PR TITLE
feat: web push 메시지 노출 개선

### DIFF
--- a/components/bucketItem/BucketItemInput.tsx
+++ b/components/bucketItem/BucketItemInput.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useMutateBucketItems } from '@/hooks/bucketlist/useMutateBucketItems';
 import styled from '@emotion/styled';
 import theme from '@/styles/theme';
-import { MAX_LENGTH__BUCKETLIST_ITEM_TITLE } from '@/utils/const';
+import { HOSTING_URL, MAX_LENGTH__BUCKETLIST_ITEM_TITLE, NOTIFICATION_ICON_URL } from '@/utils/const';
 import { useSendNotification } from '@/hooks/useSendNotification';
 import { useUser } from '@/store/useUser';
 import { useFetchGroup } from '@/hooks/group/useFetchGroup';
@@ -45,6 +45,8 @@ const BucketItemInput = ({ folderId }: { folderId: number }) => {
       group_id: selectedGroupId,
       notification_title: group.name,
       notification_body: `${user.nickname}님이 새로운 버킷리스트를 추가했습니다.`,
+      notification_icon: NOTIFICATION_ICON_URL,
+      notification_click_action: `${HOSTING_URL}/bucketlist`,
     });
   };
 

--- a/hooks/useSendNotification.ts
+++ b/hooks/useSendNotification.ts
@@ -5,6 +5,8 @@ export type SendNotificationBody = {
   group_id: number;
   notification_title: string;
   notification_body: string;
+  notification_icon: string;
+  notification_click_action: string;
 };
 
 export const useSendNotification = () => {

--- a/pages/api/fcm/send-message.ts
+++ b/pages/api/fcm/send-message.ts
@@ -9,11 +9,17 @@ export const config = {
 };
 
 const bodyScheme = z.object({
+  /** 보내는 유저 id. push 메시지 보낼 때 이 유저는 제외된다. */
   sender_id: z.number(),
+  /** push 메시지 보낼 그룹 id */
   group_id: z.number(),
+  /** push 메시지 제목 */
   notification_title: z.string(),
+  /** push 메시지 내용 */
   notification_body: z.string(),
+  /** push 메시지 아이콘 */
   notification_icon: z.string(),
+  /** push 메시지 클릭 시 이동할 url */
   notification_click_action: z.string(),
 });
 

--- a/pages/api/fcm/send-message.ts
+++ b/pages/api/fcm/send-message.ts
@@ -13,6 +13,8 @@ const bodyScheme = z.object({
   group_id: z.number(),
   notification_title: z.string(),
   notification_body: z.string(),
+  notification_icon: z.string(),
+  notification_click_action: z.string(),
 });
 
 const edgeFunction: EdgeFunction = async (req) => {
@@ -23,7 +25,15 @@ const edgeFunction: EdgeFunction = async (req) => {
     if (!refreshToken || !accessToken) throw 'no authorized';
 
     const body = await req.json();
-    const { sender_id, group_id, notification_title, notification_body } = bodyScheme.parse(body);
+    const {
+      sender_id,
+      group_id,
+      notification_title,
+      notification_body,
+      notification_icon,
+      notification_click_action,
+      //
+    } = bodyScheme.parse(body);
 
     // 1. 푸시 알림을 보내기 위한 그룹 내 다른 멤버 token들을 가져온다
     // 2. firebase http(legacy, not v1) 호출을 통해 푸시 알림을 보낸다
@@ -43,6 +53,8 @@ const edgeFunction: EdgeFunction = async (req) => {
             notification: {
               title: notification_title,
               body: notification_body,
+              icon: notification_icon,
+              click_action: notification_click_action,
             },
           }),
         });

--- a/utils/const.ts
+++ b/utils/const.ts
@@ -1,14 +1,15 @@
 import queryString from 'query-string';
 import { createQueryKeys } from './createQueryKeys';
 
-export const HOSTING_URL = process.env.NEXT_PUBLIC_HOSTING_URL || 'http://localhost:3000';
+export const LOCAL_HOSTING_URL = 'http://localhost:3000';
+export const HOSTING_URL = process.env.NEXT_PUBLIC_HOSTING_URL || LOCAL_HOSTING_URL;
 
 export const KAKAO_CLIENT_ID = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY as string;
 export const KAKAO_CLIENT_SECRET = process.env.NEXT_PUBLIC_KAKAO_CLIENT_SECRET as string;
 export const KAKAO_LOGIN_REDIRECT_URL =
-  process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URL || 'http://localhost:3000/api/auth/kakao-login';
+  process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URL || `${LOCAL_HOSTING_URL}/api/auth/kakao-login`;
 export const KAKAO_LOGOUT_REDIRECT_URL =
-  process.env.NEXT_PUBLIC_KAKAO_LOGOUT_REDIRECT_URL || 'http://localhost:3000/api/auth/kakao-logout';
+  process.env.NEXT_PUBLIC_KAKAO_LOGOUT_REDIRECT_URL || `${LOCAL_HOSTING_URL}/api/auth/kakao-logout`;
 
 export const KAKAO_LOGIN_URL = (state?: string | null) =>
   queryString.stringifyUrl({
@@ -42,6 +43,8 @@ export const INVITATION_CODE_LENGTH = 10;
 export const LOCAL_STORAGE__GROUP_ID = 'ditto-latest-group-id';
 
 export const INQUIRY_CHANNEL_URL = 'https://open.kakao.com/o/sNBgXm6e';
+
+export const NOTIFICATION_ICON_URL = `https://raw.githubusercontent.com/Nexters/ditto/main/public/favicon/android-chrome-192x192.png`;
 
 // query keys
 


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

**간단한 수정이기에 공유 차원으로 PR을 남기고, 머지는 바로 하겠습니다!**

- 두 가지 문제를 수정했습니다.
  - 푸시 메시지를 받을 때 icon이 없어 기본 이미지로 보이던 것
    - 원인: notification의 icon 필드에 아무 값도 넘기지 않고 보냈기 때문
    - 해결: 적절한 icon 이미지 url을 추가
  - 푸시 메시지를 클릭해도 어떤 반응도 없던 것
    - 원인: notification의 click_action 필드에 아무 값도 넘기지 않고 보냈기 때문
    - https://firebase.google.com/docs/cloud-messaging/http-server-ref?hl=ko#notification-payload-support
    - <img width="894" alt="스크린샷 2023-05-22 오전 12 25 59" src="https://github.com/Nexters/ditto/assets/22021344/e3e1ff62-dea7-40d5-9df7-ab576aa6575f">
    - 해결: 해당 필드에 bucketlist 페이지 url을 추가
- 결과
  - before
  - <img width="400" alt="KakaoTalk_Photo_2023-05-22-00-29-50" src="https://github.com/Nexters/ditto/assets/22021344/537f572b-1569-4b91-b33e-6b3bcb63524b">
  - after
  - <img width="400" alt="KakaoTalk_Photo_2023-05-22-00-29-54" src="https://github.com/Nexters/ditto/assets/22021344/a7142b3a-d2ba-4bae-93b4-f09b62e0f974">



