### PR TITLE
fix: notification 미동작 이슈 수정  

### DIFF
--- a/components/memberList/MemberItem.tsx
+++ b/components/memberList/MemberItem.tsx
@@ -1,4 +1,5 @@
 import theme from '@/styles/theme';
+import { toHttps } from '@/utils/url';
 import styled from '@emotion/styled';
 
 export type MemberItemProps = {
@@ -9,7 +10,12 @@ export type MemberItemProps = {
 export const MemberItem = ({ nickname, profileImage, isMe }: MemberItemProps) => {
   return (
     <MemberItemWrap>
-      <MemberItemProfileImage src={profileImage || ''} alt={`${nickname}의 프로필 이미지`} width={48} height={48} />
+      <MemberItemProfileImage
+        src={toHttps(profileImage || '')}
+        alt={`${nickname}의 프로필 이미지`}
+        width={48}
+        height={48}
+      />
       {isMe && <MemberItemIsMe>나</MemberItemIsMe>}
       <MemberItemNickname>{nickname}</MemberItemNickname>
     </MemberItemWrap>

--- a/hooks/useFirebaseMessaging.ts
+++ b/hooks/useFirebaseMessaging.ts
@@ -69,8 +69,8 @@ export const useFirebaseMessaging = () => {
     if (!messaging) return;
 
     const unsubscribe = onMessage(messaging, (payload) => {
-      const title = payload?.notification?.title ?? '';
-      const body = payload?.notification?.body;
+      const title = payload.notification?.title ?? '';
+      const body = payload.notification?.body;
       const icon = payload.notification?.icon;
 
       // @hack: onNotificationClick 핸들러를 그대로 사용하고자 data에 FCM_MSG를 넣어 internal payload처럼 처리되도록 한다.

--- a/hooks/useFirebaseMessaging.ts
+++ b/hooks/useFirebaseMessaging.ts
@@ -1,7 +1,7 @@
 import { saveToken } from '@/lib/supabase/apis/fcm';
 import { useUser } from '@/store/useUser';
 import { initializeApp } from 'firebase/app';
-import { getMessaging, getToken, Messaging, onMessage } from 'firebase/messaging';
+import { getMessaging, getToken, Messaging, onMessage, isSupported } from 'firebase/messaging';
 import { useEffect, useState } from 'react';
 
 const firebaseConfig = {
@@ -24,15 +24,18 @@ export const useFirebaseMessaging = () => {
   // notification 권한이 없는 경우 나머지 effect는 진행되지 않는다.
   useEffect(() => {
     if (!user) return;
-    if ('Notification' in window === false) return;
 
     const app = initializeApp(firebaseConfig);
-    const messaging = getMessaging(app);
 
-    Notification.requestPermission()
+    isSupported()
+      .then((supported) => {
+        if (!supported) throw 'not supported firebase messaging';
+        return Notification.requestPermission();
+      })
       .then((permission) => {
         if (permission !== 'granted') return;
 
+        const messaging = getMessaging(app);
         setMessaging(messaging);
       })
       .catch(console.error);

--- a/pages/api/fcm/send-message.ts
+++ b/pages/api/fcm/send-message.ts
@@ -48,6 +48,7 @@ const edgeFunction: EdgeFunction = async (req) => {
     const serverKey = process.env.NEXT_PUBLIC_FCM_SERVER_KEY as string;
     const results = await Promise.all(
       fcmTokens.map(async ({ token }) => {
+        // docs link: https://firebase.google.com/docs/cloud-messaging/http-server-ref?hl=ko
         const res = await fetch('https://fcm.googleapis.com/fcm/send', {
           method: 'post',
           headers: {
@@ -55,6 +56,9 @@ const edgeFunction: EdgeFunction = async (req) => {
             Authorization: `key=${serverKey}`,
           },
           body: JSON.stringify({
+            // @note: 비활성화 앱을 활성화시키기 위해 아래 두 옵션을 추가함
+            content_available: true,
+            priority: 'high',
             to: token,
             notification: {
               title: notification_title,

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -1,0 +1,3 @@
+export const toHttps = (url: string) => {
+  return url.replace('http://', 'https://');
+};


### PR DESCRIPTION
### 이슈 번호

Nexters/ditto#

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

- FCM을 통한 푸시 알림을 보내도 특정 사용자에게 바로 전달되도록 메시지에 옵션값을 2가지 추가했습니다.
  - https://velog.io/@ysung327/FCM-4%ED%8E%B8%EB%A9%94%EC%8B%9C%EC%A7%95-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
- foreground(=focus) 시 생성된 notification을 클릭해도 반응없던 이슈를 수정했습니다.
- 기타: iOS, iPadOS의 Safari에서 프로필 이미지가 http로 시작하는경우 보이지 않아 https로 변환하는 유틸을 추가해 수정했습니다.
